### PR TITLE
Feature/exercise6 - abstract useKeyPress effect into a custom hook and import it into ToastProvider

### DIFF
--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -1,4 +1,5 @@
 import React from "react";
+import useKeyPress from "../../hooks/useKeyPress";
 
 export const ToastContext = React.createContext();
 
@@ -16,18 +17,12 @@ function ToastProvider({ children }) {
     const newToastArray = [...toastArray, newToast];
     setToastArray(newToastArray);
   };
-  // effect to dismiss all toasts 
-  React.useEffect(() => {
-    const handleKeyPress = (event) => {
-      if (event.code === 'Escape') {
-        setToastArray([]);
-      }
-    }
-    window.addEventListener('keydown', handleKeyPress);
-    return () => {
-      window.removeEventListener('keydown', handleKeyPress)
-    }
+  // memoize callback to avoid rerender
+  const handleKeyPress = React.useCallback(() => {
+    setToastArray([]);
   }, []);
+  // effect to dismiss all toasts
+  useKeyPress(handleKeyPress, "Escape");
   return (
     <ToastContext.Provider value={{ toastArray, dismissToast, addNewToast }}>
       {children}

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const useKeyPress = (callback, key) => {
+    React.useEffect(() => {
+        const handleKeyPress = (event) => {
+          if (event.code === key) {
+            callback();
+          }
+        }
+        window.addEventListener('keydown', handleKeyPress);
+        return () => {
+          window.removeEventListener('keydown', handleKeyPress)
+        }
+      }, [callback, key]);
+}
+
+export default useKeyPress;


### PR DESCRIPTION
+ Move effect that manages "escape" keypress into a custom hook.
+ Modify hook to allow consumer to pass in callback and key to activate it.
+ import custom keypress hook into ToastProvider.
+ memoize callback to avoid unnecessary rerenders.